### PR TITLE
[Fix] Fix error in treeWalker on Internet Explorer >= 9.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error in treeWalker on Internet Explorer >= 9.
+  [Kevin Bieri]
 
 
 1.0.0 (2016-11-30)

--- a/ftw/candlestick/js/src/DOMParser.js
+++ b/ftw/candlestick/js/src/DOMParser.js
@@ -1,6 +1,5 @@
 import { parse, matchPhoneGroups, createPhoneLink } from "./phonevalidator";
 
-const textNodeFilter = { acceptNode: acceptNodeFilter }
 const escapeStringRegExp = require("escape-string-regexp");
 const includes = require("array-includes");
 
@@ -61,7 +60,7 @@ export function replaceTextNodes(textNode, subStr=[], newNodes=[]) {
 }
 
 export function extractTextNodesUnder(root) {
-  return extractNodes(document.createTreeWalker(root, NodeFilter.SHOW_TEXT, textNodeFilter, false));
+  return extractNodes(document.createNodeIterator(root, NodeFilter.SHOW_TEXT, acceptNodeFilter, false));
 }
 
 export function replaceTextNodesUnder(root) {

--- a/ftw/candlestick/resources/ftw.candlestick.js
+++ b/ftw/candlestick/resources/ftw.candlestick.js
@@ -13,7 +13,6 @@ exports.replaceTextNodesUnder = replaceTextNodesUnder;
 
 var _phonevalidator = require("./phonevalidator");
 
-var textNodeFilter = { acceptNode: acceptNodeFilter };
 var escapeStringRegExp = require("escape-string-regexp");
 var includes = require("array-includes");
 
@@ -85,7 +84,7 @@ function replaceTextNodes(textNode) {
 }
 
 function extractTextNodesUnder(root) {
-  return extractNodes(document.createTreeWalker(root, NodeFilter.SHOW_TEXT, textNodeFilter, false));
+  return extractNodes(document.createNodeIterator(root, NodeFilter.SHOW_TEXT, acceptNodeFilter, false));
 }
 
 function replaceTextNodesUnder(root) {


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.candlestick/issues/8

http://stackoverflow.com/questions/38245898/createnodeiterator-fails-in-ie9-when-acceptnode-is-specified