### PR TITLE
Fix parse and replace issues.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,12 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix parse and replace issues.
+
+  - Parentheses should not be included in the phone links.
+  - Trailing text should not be ignored.
+
+  [Kevin Bieri]
 
 
 1.0.1 (2017-01-13)

--- a/ftw/candlestick/js/src/DOMParser.js
+++ b/ftw/candlestick/js/src/DOMParser.js
@@ -2,6 +2,7 @@ import { parse, matchPhoneGroups, createPhoneLink } from "./phonevalidator";
 
 const escapeStringRegExp = require("escape-string-regexp");
 const includes = require("array-includes");
+const zipLongest = require("zip-array").zip_longest;
 
 const blacklist = [
   "A",
@@ -54,6 +55,8 @@ export function replaceTextNodes(textNode, subStr=[], newNodes=[]) {
       parentNode.insertBefore(gabs[index].cloneNode(true), textNode);
       parentNode.insertBefore(match.cloneNode(true), textNode);
     });
+
+    parentNode.insertBefore(gabs[gabs.length - 1].cloneNode(true), textNode);
 
     parentNode.removeChild(textNode);
   }

--- a/ftw/candlestick/js/src/DOMParser.js
+++ b/ftw/candlestick/js/src/DOMParser.js
@@ -2,7 +2,6 @@ import { parse, matchPhoneGroups, createPhoneLink } from "./phonevalidator";
 
 const escapeStringRegExp = require("escape-string-regexp");
 const includes = require("array-includes");
-const zipLongest = require("zip-array").zip_longest;
 
 const blacklist = [
   "A",

--- a/ftw/candlestick/js/src/phonevalidator.js
+++ b/ftw/candlestick/js/src/phonevalidator.js
@@ -6,7 +6,7 @@ const PhoneNumberFormat = require("google-libphonenumber").PhoneNumberFormat;
 
 const defaultCountry = "CH"; // ISO 3166-1 two-letter country code
 
-const possibleNumberRegEx = /([\+0\t ]*41)?[\(\)\t \/\\0]*(\d{2,3}[\(\)\t \/\\]+){2,3}(\d{2,3}[\(\)\t \/\\]*){1}/g;
+const possibleNumberRegEx = /([\+0\t ]*41( \(0\))?)?[\t \/\\0]*(\d{2,3}[\t \/\\]+){2,3}(\d{2,3}[\t \/\\]*){1}/g;
 
 /*
   This function tries to find phone number candidates out

--- a/ftw/candlestick/js/test/fixtures/parentheses.html
+++ b/ftw/candlestick/js/test/fixtures/parentheses.html
@@ -1,0 +1,2 @@
+<p id="actual">Thomas Lötscher, Generalsekretär (041 728 36 02).</p>
+<p id="expected">Thomas Lötscher, Generalsekretär (<a href="tel:+41417283602">041 728 36 02</a>).</p>

--- a/ftw/candlestick/js/test/fixtures/trailing_text.html
+++ b/ftw/candlestick/js/test/fixtures/trailing_text.html
@@ -1,0 +1,2 @@
+<p id="actual">041 759 80 18 Text</p>
+<p id="expected"><a href="tel:+41417598018">041 759 80 18</a> Text</p>

--- a/ftw/candlestick/js/test/spec/DOMParser.js
+++ b/ftw/candlestick/js/test/spec/DOMParser.js
@@ -118,7 +118,7 @@ describe("DOMParser", () => {
       const textNode = fixture.el.querySelector("p").childNodes[0];
       replaceTextNodesUnder(fixture.el);
       assert.equal(fixture.el.querySelector("p").outerHTML,
-        '<p>Handy: <a href="tel:+41769867825">(076 986 78 25)</a> erreichbar oder privat <a href="tel:+41339769209">+ 41 (0)33 976 92 09</a></p>'
+        '<p>Handy: (<a href="tel:+41769867825">076 986 78 25</a>) erreichbar oder privat <a href="tel:+41339769209">+ 41 (0)33 976 92 09</a></p>'
       );
     });
 

--- a/ftw/candlestick/js/test/spec/integration.js
+++ b/ftw/candlestick/js/test/spec/integration.js
@@ -20,4 +20,12 @@ describe("Integration", () => {
     assert.equal(stripWhitespace(stripNewline(actual)), stripWhitespace(stripNewline(expected)));
   });
 
+  it("should apply trailing text", () => {
+    fixture.load("trailing_text.html");
+    linkPhoneNumbers("#actual");
+    const actual = fixture.el.querySelector("#actual").innerHTML;
+    const expected = fixture.el.querySelector("#expected").innerHTML;
+    assert.equal(stripWhitespace(stripNewline(actual)), stripWhitespace(stripNewline(expected)));
+  });
+
 });

--- a/ftw/candlestick/js/test/spec/integration.js
+++ b/ftw/candlestick/js/test/spec/integration.js
@@ -28,4 +28,12 @@ describe("Integration", () => {
     assert.equal(stripWhitespace(stripNewline(actual)), stripWhitespace(stripNewline(expected)));
   });
 
+  it("should not include parentheses in the phonelink", () => {
+    fixture.load("parentheses.html");
+    linkPhoneNumbers("#actual");
+    const actual = fixture.el.querySelector("#actual").innerHTML;
+    const expected = fixture.el.querySelector("#expected").innerHTML;
+    assert.equal(stripWhitespace(stripNewline(actual)), stripWhitespace(stripNewline(expected)));
+  });
+
 });

--- a/ftw/candlestick/js/test/spec/phonevalidator.js
+++ b/ftw/candlestick/js/test/spec/phonevalidator.js
@@ -65,7 +65,7 @@ describe("Phonevalidator", () => {
 
       assert.deepEqual(
         matchPhoneGroups(possiblePhoneNumbers),
-        ["(076 986 78 25)", "+ 41 (0)33 976 92 09"]
+        ["076 986 78 25", "+ 41 (0)33 976 92 09"]
       )
     });
   });

--- a/ftw/candlestick/resources/ftw.candlestick.js
+++ b/ftw/candlestick/resources/ftw.candlestick.js
@@ -78,6 +78,8 @@ function replaceTextNodes(textNode) {
         parentNode.insertBefore(match.cloneNode(true), textNode);
       });
 
+      parentNode.insertBefore(gabs[gabs.length - 1].cloneNode(true), textNode);
+
       parentNode.removeChild(textNode);
     })();
   }
@@ -121,7 +123,7 @@ var PhoneNumberFormat = require("google-libphonenumber").PhoneNumberFormat;
 
 var defaultCountry = "CH"; // ISO 3166-1 two-letter country code
 
-var possibleNumberRegEx = /([\+0\t ]*41)?[\(\)\t \/\\0]*(\d{2,3}[\(\)\t \/\\]+){2,3}(\d{2,3}[\(\)\t \/\\]*){1}/g;
+var possibleNumberRegEx = /([\+0\t ]*41( \(0\))?)?[\t \/\\0]*(\d{2,3}[\t \/\\]+){2,3}(\d{2,3}[\t \/\\]*){1}/g;
 
 /*
   This function tries to find phone number candidates out


### PR DESCRIPTION
Closes https://extranet.4teamwork.ch/support/zug/maintlog/11141

- Parentheses should not be included in the phone links e.g.
``` diff
- <a href="tel:41414762890">(+41 476 28 90)</a>
+ (<a href="tel:41414762890">+41 476 28 90</a>)
```

- Trailing text should not be ignored e.g.
``` diff
- <p>Please call <a href="tel:41414762890">+41 476 28 90</a></p>
+ <p>Please call <a href="tel:41414762890">+41 476 28 90</a> for more information</p>
```

In the following example look at the links in red.

## Before
![screen shot 2017-03-09 at 17 02 55](https://cloud.githubusercontent.com/assets/1637820/23759484/3a409c4a-04ed-11e7-8f96-181c90011e93.png)
![screen shot 2017-03-09 at 17 06 27](https://cloud.githubusercontent.com/assets/1637820/23759483/3a40ace4-04ed-11e7-88bd-3e86382204fe.png)

## After
![screen shot 2017-03-09 at 17 06 39](https://cloud.githubusercontent.com/assets/1637820/23759505/48138ca6-04ed-11e7-90fc-b7282f0d8ac8.png)
![screen shot 2017-03-09 at 17 03 46](https://cloud.githubusercontent.com/assets/1637820/23759506/48153f24-04ed-11e7-8828-ea3aa79fc58c.png)
