### PR TITLE
Fix buildout for JavaScript test 

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-javascript.cfg
     test-plone-5.1.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-javascript.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pin down setuptools for Python 2.7 compatibility reasons. [busykoala]
 
 
 1.1.4 (2019-12-17)

--- a/test-javascript.cfg
+++ b/test-javascript.cfg
@@ -1,2 +1,5 @@
 [buildout]
 extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-javascript.cfg
+
+[versions]
+setuptools = <45


### PR DESCRIPTION
Setuptools is unpinned in `test-versions.cfg` which is a dependency of `test-javascript.cfg`. By changing the order in the end setuptools is restricted to versions <45 which is necessery in Python 2.7.

Setuptools have to be pinned down because they are not compatible with Python 2.7 from <=46.